### PR TITLE
fix(js): Fix replay button by reloading the page

### DIFF
--- a/script.js
+++ b/script.js
@@ -338,13 +338,8 @@ gsap.to(finalCard, {autoAlpha:0, duration:0.6, onComplete:()=>gsap.set(finalCard
 function setupReplay(){
 const btn = document.getElementById('replayBtn');
 btn.addEventListener('click', ()=>{
-// scroll to top
-window.scrollTo({top:0,behavior:'smooth'});
-// re-run converge after a short delay when scroll returns to top
-setTimeout(()=>{
-// quick disperse to ensure particles back to orig
-disperseParticles();
-}, 700);
+// Simple reload is the most robust way to reset the complex animation state
+location.reload();
 });
 }
 


### PR DESCRIPTION
The replay button did not correctly reset the GSAP ScrollTrigger timeline, causing the animation to be "stuck" on the initial screen after one playthrough.

This change replaces the faulty reset logic with a simple and robust `location.reload()` call. This ensures that the entire animation state is reset correctly, allowing the user to replay the experience reliably.