### PR TITLE
The script was attempting to load 'compassion.png', but the actual fi…

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,7 +77,7 @@ particles.push(s);
 const loader = new PIXI.Loader();
 loader
 .add('devotion', 'devotion.png')
-.add('compassion', 'compassion.png')
+.add('compassion', 'compassion.jpg')
 .add('wanderlust', 'wanderlust.png')
 .load((loader, resources) => {
 // create sprites and place at z-depths


### PR DESCRIPTION
…le is 'compassion.jpg'. This change corrects the file path in the PixiJS loader to prevent a 404 error and ensure the image loads correctly.