### PR TITLE
Fix: Debounce resize event to prevent layout issues

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,3 +1,15 @@
+function debounce(func, wait) {
+  let timeout;
+  return function executedFunction(...args) {
+    const later = () => {
+      clearTimeout(timeout);
+      func(...args);
+    };
+    clearTimeout(timeout);
+    timeout = setTimeout(later, wait);
+  };
+}
+
 /*
 script.js
 - Uses PixiJS for the particle field and images
@@ -141,9 +153,9 @@ particles[i].y += Math.cos((Date.now()/1000 + i) * 0.2) * 0.06 * (1 + (2000 - pa
 });
 
 // handle resize
-window.addEventListener('resize', ()=>{
-app.renderer.resize(window.innerWidth, window.innerHeight);
-});
+window.addEventListener('resize', debounce(() => {
+  location.reload();
+}, 250));
 }
 
 // Scroll-driven timeline using GSAP ScrollTrigger


### PR DESCRIPTION
The application's layout would break upon resizing the browser window because element positions were not recalculated.

This commit fixes the issue by implementing a debounced page reload on the resize event. A debounce utility function is added to prevent rapid reloads during the resize action. Now, when the user resizes the window, the page will reload after 250ms of inactivity, ensuring the layout and animations are correctly re-initialized for the new viewport size.